### PR TITLE
Fix array index

### DIFF
--- a/app/Domains/User/Action/SessionTFA.php
+++ b/app/Domains/User/Action/SessionTFA.php
@@ -45,6 +45,6 @@ class SessionTFA extends ActionAbstract
             return true;
         }
 
-        return (time() - $id[3]) < (3600 * 6);
+        return (time() - $id[2]) < (3600 * 6);
     }
 }


### PR DESCRIPTION
`$id` explodes to `[xxx, ip, timestamp]`, `$id[3]` should be `$id[2]`, `$id[3]` is out of range.