### PR TITLE
Added enforcement of https

### DIFF
--- a/app/Providers/App.php
+++ b/app/Providers/App.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\URL;
 
 class App extends ServiceProvider
 {
@@ -13,6 +14,10 @@ class App extends ServiceProvider
     public function boot(): void
     {
         $this->locale();
+        if (env('APP_ENV') === 'production' && str_starts_with(env('APP_URL'),'https')) {
+            $this->app['request']->server->set('HTTPS','on');
+            URL::forceScheme('https');
+        }
     }
 
     /**


### PR DESCRIPTION
Hi @eusonlito ,
during my initial experiments I stumbled across the same problem as mentioned in https://github.com/eusonlito/Password-Manager/issues/28 . Therefore, I created this little pull request where I added the enforcement of HTTPS in case APP_ENV is set to "production" and the APP_URL starts with "https://"