### PR TITLE
Hide ':' in server listing when port is empty

### DIFF
--- a/resources/views/domains/app/types/server/list.blade.php
+++ b/resources/views/domains/app/types/server/list.blade.php
@@ -1,6 +1,6 @@
 <td>
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy>{{ ($row->payload('host')) }}</a>
-    :
+    @if($row->payload('port')):@endif
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy-ajax="{{ route('app.payload.key', [$row->id, 'port']) }}">@hidden($row->payload('port'))</a>
 </td>
 <td>

--- a/resources/views/domains/app/types/server/list.blade.php
+++ b/resources/views/domains/app/types/server/list.blade.php
@@ -1,7 +1,10 @@
 <td>
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy>{{ ($row->payload('host')) }}</a>
-    @if($row->payload('port')):@endif
+    
+    @if ($row->payload('port'))
+    :
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy-ajax="{{ route('app.payload.key', [$row->id, 'port']) }}">@hidden($row->payload('port'))</a>
+    @endif
 </td>
 <td>
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy-ajax="{{ route('app.payload.key', [$row->id, 'user']) }}">@hidden($row->payload('user'))</a>


### PR DESCRIPTION
Small contribution, hides the colon (':') in the server listing if the port number has not been filled.