### PR TITLE
display username and password in correct columns for user-password types

### DIFF
--- a/resources/views/domains/app/types/user-password/list.blade.php
+++ b/resources/views/domains/app/types/user-password/list.blade.php
@@ -1,7 +1,7 @@
+<td></td>
 <td>
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy-ajax="{{ route('app.payload.key', [$row->id, 'user']) }}">@hidden($row->payload('user'))</a>
 </td>
 <td>
     <a href="javascript:;" class="tooltip" title="{{ __('common.copy') }}" data-tippy-content="{{ __('common.copied') }}" data-copy-ajax="{{ route('app.payload.key', [$row->id, 'password']) }}">@hidden($row->payload('password'))</a>
 </td>
-<td></td>


### PR DESCRIPTION
Before this fix, username was displayed in the URL column, password in the user column, and the password column was emtpy.

Now, URL column will be empty, username and password are now in the correct columns.